### PR TITLE
1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,12 @@ create_xcframework(
     workspace: 'path/to/your.xcworkspace',
     scheme: 'framework scheme',
     product_name: 'Sample', # optional if scheme doesnt match the name of your framework
-    include_bitcode: true,
-    destinations: ['iOS', 'maccatalyst'], # 
+    destinations: ['iOS', 'maccatalyst'],
     xcframework_output_directory: 'path/to/your/output dir'
 )
 ```
 
-Run 
+Run
 ```bash
 $ fastlane actions create_xcframework
 ```
@@ -47,7 +46,6 @@ to learn more about the plugin.
 * watchOS
 * carPlayOS
 * macOS
-
 
 ## Output
 

--- a/lib/fastlane/plugin/create_xcframework/helper/create_xcframework_helper.rb
+++ b/lib/fastlane/plugin/create_xcframework/helper/create_xcframework_helper.rb
@@ -33,23 +33,23 @@ module Fastlane
       end
 
       def xcarchive_dSYMs_path(framework_index)
-        "#{xcarchive_path(framework_index)}/dSYMS"
+        File.expand_path("#{xcarchive_path(framework_index)}/dSYMS")
       end
 
       def xcframework_dSYMs_path
-        "#{output_directory}/#{product_name}.dSYMs"
+        File.expand_path("#{output_directory}/#{product_name}.dSYMs")
       end
 
       def xcarchive_BCSymbolMaps_path(framework_index)
-        "#{xcarchive_path(framework_index)}/BCSymbolMaps"
+        File.expand_path("#{xcarchive_path(framework_index)}/BCSymbolMaps")
       end
 
       def xcframework_BCSymbolMaps_path
-        "#{output_directory}/#{product_name}.BCSymbolMaps"
+        File.expand_path("#{output_directory}/#{product_name}.BCSymbolMaps")
       end
 
       def xcframework_path
-        "#{output_directory}/#{xcframework}"
+        File.expand_path("#{output_directory}/#{xcframework}")
       end
 
       def output_directory

--- a/lib/fastlane/plugin/create_xcframework/version.rb
+++ b/lib/fastlane/plugin/create_xcframework/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module CreateXcframework
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end


### PR DESCRIPTION
Adds two new options for Xcode 12 and above:

- include_dSYMs
- include_BCSymbolMaps

`include_bitcode` is no longer required == optional

Example:
```
  create_xcframework(
    scheme: 'iOSModule',
    workspace: 'XCFramework.xcworkspace',
    include_dSYMs: true, // optional, default: true
    include_BCSymbolMaps: true, // optional, default: true
    include_bitcode: true, // optional, default: true
    destinations: ['iOS', 'maccatalyst'],
    xcframework_output_directory: 'Products/xcframeworks'
  )
```

or simplified version of the above (default) case:
```
  create_xcframework(
    scheme: 'iOSModule',
    workspace: 'XCFramework.xcworkspace',
    destinations: ['iOS', 'maccatalyst'],
    xcframework_output_directory: 'Products/xcframeworks'
  )
```

<img width="298" alt="Screenshot 2020-09-20 at 08 56 31" src="https://user-images.githubusercontent.com/4924709/93705653-2fa32380-fb1f-11ea-970f-77621690eb9a.png">