### PR TITLE
Parametrize xcargs override

### DIFF
--- a/lib/fastlane/plugin/create_xcframework/actions/create_xcframework_action.rb
+++ b/lib/fastlane/plugin/create_xcframework/actions/create_xcframework_action.rb
@@ -15,7 +15,9 @@ module Fastlane
         if Helper.xcode_at_least?('11.0.0')
           verify_delicate_params(params)
           params[:destinations] = update_destinations(params)
-          params[:xcargs] = update_xcargs(params)
+          if params[:override_xcargs]
+            params[:xcargs] = update_xcargs(params)
+          end
 
           @xchelper = Helper::CreateXcframeworkHelper.new(params)
 
@@ -257,6 +259,13 @@ module Fastlane
             key: :remove_xcarchives,
             description: 'This option will auto-remove the xcarchive files once the plugin finishes.' \
                           'Set this to false to preserve the xcarchives',
+            optional: true,
+            default_value: true
+          ),
+          FastlaneCore::ConfigItem.new(
+            key: :override_xcargs,
+            description: 'This option will update xcargs to override SKIP_INSTALL and BUILD_LIBRARY_FOR_DISTRIBUTION options' \
+                          'Set this to false to preserve the xcargs',
             optional: true,
             default_value: true
           )

--- a/lib/fastlane/plugin/create_xcframework/actions/create_xcframework_action.rb
+++ b/lib/fastlane/plugin/create_xcframework/actions/create_xcframework_action.rb
@@ -144,7 +144,7 @@ module Fastlane
           xcargs << ['OTHER_CFLAGS="-fembed-bitcode"', 'BITCODE_GENERATION_MODE="bitcode"', 'ENABLE_BITCODE=YES']
         end
 
-        params[:xcargs].to_s + xcargs.join(' ')
+        params[:xcargs].to_s + ' ' + xcargs.join(' ')
       end
 
       def self.update_destinations(params)

--- a/lib/fastlane/plugin/create_xcframework/actions/create_xcframework_action.rb
+++ b/lib/fastlane/plugin/create_xcframework/actions/create_xcframework_action.rb
@@ -15,9 +15,7 @@ module Fastlane
         if Helper.xcode_at_least?('11.0.0')
           verify_delicate_params(params)
           params[:destinations] = update_destinations(params)
-          if params[:override_xcargs]
-            params[:xcargs] = update_xcargs(params)
-          end
+          params[:xcargs] = update_xcargs(params)
 
           @xchelper = Helper::CreateXcframeworkHelper.new(params)
 
@@ -130,13 +128,16 @@ module Fastlane
       end
 
       def self.update_xcargs(params)
-        FastlaneCore::UI.important('Overwriting SKIP_INSTALL and BUILD_LIBRARY_FOR_DISTRIBUTION options')
-        if params[:xcargs]
-          params[:xcargs].gsub!(/SKIP_INSTALL(=|\s+)(YES|NO)/, '')
-          params[:xcargs].gsub!(/BUILD_LIBRARY_FOR_DISTRIBUTION(=|\s+)(YES|NO)/, '')
-          params[:xcargs] += ' '
+        xcargs = []
+        if params[:override_xcargs]
+          FastlaneCore::UI.important('Overwriting SKIP_INSTALL and BUILD_LIBRARY_FOR_DISTRIBUTION options')
+          if params[:xcargs]
+            params[:xcargs].gsub!(/SKIP_INSTALL(=|\s+)(YES|NO)/, '')
+            params[:xcargs].gsub!(/BUILD_LIBRARY_FOR_DISTRIBUTION(=|\s+)(YES|NO)/, '')
+            params[:xcargs] += ' '
+          end
+          xcargs.concat(['SKIP_INSTALL=NO', 'BUILD_LIBRARY_FOR_DISTRIBUTION=YES'])
         end
-        xcargs = ['SKIP_INSTALL=NO', 'BUILD_LIBRARY_FOR_DISTRIBUTION=YES']
 
         if params[:enable_bitcode] != false
           params[:xcargs].gsub!(/ENABLE_BITCODE(=|\s+)(YES|NO)/, '') if params[:xcargs]
@@ -264,8 +265,9 @@ module Fastlane
           ),
           FastlaneCore::ConfigItem.new(
             key: :override_xcargs,
-            description: 'This option will update xcargs to override SKIP_INSTALL and BUILD_LIBRARY_FOR_DISTRIBUTION options' \
-                          'Set this to false to preserve the xcargs',
+            description: 'This option will override xcargs SKIP_INSTALL and BUILD_LIBRARY_FOR_DISTRIBUTION.' \
+                          'If set to true, SKIP_INSTALL will be set to NO and BUILD_LIBRARY_FOR_DISTRIBUTION will be set to YES' \
+                          'Set this to false to preserve the passed xcargs',
             optional: true,
             default_value: true
           )


### PR DESCRIPTION
## Description
We have a use case in which we are building some dependencies without library evolution, although we still build the framework with BUILD_LIBRARY_FOR_DISTRIBUTION
By forcing the xcarg from this plugin, it causes all our other dependencies to also be built with BUILD_LIBRARY_FOR_DISTRIBUTION set to YES. Since we are using those dependencies internally and they are not part of the interface of our module, we are importing them with `@_implementationOnly import 3rdPartyModule`, and it is fine to build them without BUILD_LIBRARY_FOR_DISTRIBUTION enabled.

We are handling the BUILD_LIBRARY_FOR_DISTRIBUTION configuration from the scheme in our Xcode project, so it would be great for us if we can have the plugin not override our configuration.

### Related issues
This addresses https://github.com/bielikb/fastlane-plugin-create_xcframework/issues/10

## Summary of changes

- Add a new configuration parameter to the plugin
- Default it to true to keep default behaviour as it was before
- Skip overriding BUILD_LIBRARY_FOR_DISTRIBUTION and SKIP_INSTALL when the parameter is set to false in the update_xcargs func
- Add missing space when joining the xcargs passed as a param with the overridden ones (pre-existing bug)