### PR TITLE
fix `include_debug_symbols` doesn't work unless explicitly set

### DIFF
--- a/lib/fastlane/plugin/create_xcframework/actions/create_xcframework_action.rb
+++ b/lib/fastlane/plugin/create_xcframework/actions/create_xcframework_action.rb
@@ -72,7 +72,8 @@ module Fastlane
       end
 
       def self.debug_symbols(index:, params:)
-        return '' unless Helper.xcode_at_least?('12.0.0') && params[:include_debug_symbols] == true
+        return '' unless Helper.xcode_at_least?('12.0.0') 
+        return '' if params[:include_debug_symbols] == false
 
         debug_symbols = []
 

--- a/spec/fastlane_create_xcframework_action_spec.rb
+++ b/spec/fastlane_create_xcframework_action_spec.rb
@@ -217,6 +217,20 @@ describe Fastlane do
         expect(result).to eq(expected_result)
       end
 
+      it 'verifies debug_symbols method when :include_debug_symbols option was not provided' do
+        test_data = 'testme'
+        allow(nil).to receive(:xcarchive_BCSymbolMaps_path).and_return(test_data)
+        allow(nil).to receive(:xcarchive_dSYMs_path).and_return(test_data)
+        allow(nil).to receive(:framework).and_return(test_data)
+        allow(File).to receive(:expand_path).and_return(test_data)
+        allow(Dir).to receive(:exist?).and_return(true)
+        allow(Dir).to receive(:children).and_return([test_data])
+        allow(Fastlane::Helper).to receive(:xcode_at_least?).and_return(true)
+        result = described_class.debug_symbols(index: 0, params: { })
+        expected_result = "-debug-symbols #{test_data}/#{test_data}.dSYM -debug-symbols #{test_data}"
+        expect(result).to eq(expected_result)
+      end
+
       it 'verifies debug_symbols method when :include_dSYMs option is equals to false' do
         test_data = 'testme'
         allow(nil).to receive(:xcarchive_BCSymbolMaps_path).and_return(test_data)


### PR DESCRIPTION
Fixes #16 

# Changes
If the `include_debug_symbols` parameter is omitted, debug symbols will be included in the `.xcframework` folder by default.

## References
- #16 

## Risks
- [ ] None
- [X] Low
- [ ] High

I consider this low risk, since it would only add files to the `.xcframework` folder, it would only affect projects that are omitting the parameter, and it's what I would have considered expected behavior since the parameter defaults to true according to the docs. 

Happy to close if the previous behavior was expected, though!! 
And let me know if I missed anything. 
