### PR TITLE
Properly treating parameters within the action

### DIFF
--- a/fastlane-plugin-create_xcframework.gemspec
+++ b/fastlane-plugin-create_xcframework.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.4'
+  spec.required_ruby_version = '>= 2.6'
   spec.add_development_dependency('bundler')
   spec.add_development_dependency('fasterer', '0.9.0')
   spec.add_development_dependency('fastlane', '>= 2.182.0')

--- a/spec/fastlane_create_xcframework_action_spec.rb
+++ b/spec/fastlane_create_xcframework_action_spec.rb
@@ -7,7 +7,7 @@ describe Fastlane do
 
       it 'verifies available_destinations method' do
         expected_destinations = [
-          'iOS', 'iPadOS', 'macOS', 'tvOS', 'watchOS', 'carPlayOS', 'maccatalyst'
+          'iOS', 'iPadOS', 'macOS', 'tvOS', 'watchOS', 'carPlayOS', 'maccatalyst', 'visionOS'
         ]
         actual_destinations = described_class.available_destinations.keys
         expect(actual_destinations.sort).to eq(expected_destinations.sort)
@@ -133,7 +133,7 @@ describe Fastlane do
       end
 
       it 'verifies copy_dSYMs method when :include_dSYMs option is equals to false' do
-        params = { include_dSYMs: false }
+        params = { include_debug_symbols: false }
         described_class.copy_dSYMs(params)
         expect(FileUtils).not_to receive(:mkdir_p)
       end
@@ -146,7 +146,7 @@ describe Fastlane do
         allow(FileUtils).to receive(:mkdir_p)
         allow(FileUtils).to receive(:cp_r)
 
-        params = { include_dSYMs: false }
+        params = { include_debug_symbols: true, destinations: ['iOS'] }
         described_class.copy_dSYMs(params)
         expect(FileUtils).not_to receive(:mkdir_p)
       end


### PR DESCRIPTION
## Changes

The action wasn't properly handling dSYM- related parameters. Also, it wasn't properly constructing default values of parameters due to the fact that it was concatenating its list of fastlane `ConfigItems` with the `XcarchiveAction.available_options` which is just a list of plain strings, thus bypassing fastlane's proper initialization of the action's parameters.

## Risks
- [x] None
- [ ] Low
- [ ] High
